### PR TITLE
Add: 完了・未完了の切り替えと削除機能を追加しました

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,22 @@ function App() {
     setTodos((prevTodos) => [...prevTodos, newTodo]);
   };
 
+  const handleToggleTodo = (id: string) => {
+    setTodos((prevTodos) => {
+      return prevTodos.map((todo) => {
+        if (todo.id === id) {
+          return { ...todo, isCompleted: !todo.isCompleted };
+        } else {
+          return todo;
+        }
+      });
+    });
+  };
+
+  const handleDeleteTodo = (id: string) => {
+    setTodos((prevTodos) => prevTodos.filter((todo) => todo.id !== id));
+  };
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -70,7 +86,11 @@ function App() {
             mt: 2,
           }}
         >
-          <TodoList todos={todos} />
+          <TodoList
+            todos={todos}
+            onToggleComplete={handleToggleTodo}
+            onDelete={handleDeleteTodo}
+          />
         </Box>
       </Box>
     </ThemeProvider>

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -2,7 +2,19 @@ import { Box, Checkbox, IconButton, ListItem, Typography } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import type { Todo } from "../types";
 
-export default function TodoItem({ id, task, isCompleted }: Todo) {
+type TodoItemProps = {
+  todo: Todo;
+  onToggleComplete: (id: string) => void;
+  onDelete: (id: string) => void;
+};
+
+export default function TodoItem({
+  todo,
+  onToggleComplete,
+  onDelete,
+}: TodoItemProps) {
+  const { id, task, isCompleted } = todo;
+
   return (
     <>
       <ListItem
@@ -21,18 +33,28 @@ export default function TodoItem({ id, task, isCompleted }: Todo) {
             minWidth: 0,
           }}
         >
-          <Checkbox defaultChecked={isCompleted} sx={{ p: 1 }} />
+          <Checkbox
+            checked={isCompleted}
+            sx={{ p: 1 }}
+            onChange={() => onToggleComplete(id)}
+          />
           <Typography
             sx={{
               flexGrow: 1,
               whiteSpace: "nowrap",
               overflowX: "auto",
+              textDecoration: isCompleted ? "line-through" : "none",
+              color: isCompleted ? "text.secondary" : "text.primary",
             }}
           >
             {task}
           </Typography>
         </Box>
-        <IconButton aria-label="delete" size="small">
+        <IconButton
+          aria-label="delete"
+          size="small"
+          onClick={() => onDelete(id)}
+        >
           <DeleteIcon />
         </IconButton>
       </ListItem>

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -4,15 +4,28 @@ import type { Todo } from "../types";
 
 type TodoListProps = {
   todos: Todo[];
+  onToggleComplete: (id: string) => void;
+  onDelete: (id: string) => void;
 };
 
-export default function TodoList({ todos }: TodoListProps) {
+export default function TodoList({
+  todos,
+  onToggleComplete,
+  onDelete,
+}: TodoListProps) {
   return (
     <List>
       {todos.length === 0 ? (
         <Typography>すべてのタスクが完了しました！</Typography>
       ) : (
-        todos.map((todo) => <TodoItem key={todo.id} {...todo}></TodoItem>)
+        todos.map((todo) => (
+          <TodoItem
+            key={todo.id}
+            todo={todo}
+            onToggleComplete={onToggleComplete}
+            onDelete={onDelete}
+          />
+        ))
       )}
     </List>
   );


### PR DESCRIPTION
## 概要

### このPRで何をしたか？

- タスクの完了・未完了を切り替えられる機能を追加
- タスクの削除ができる機能を追加

### なぜこのPRが必要だったのか？

- ユーザーがタスクの完了・未完了を切り替えられるようにするため
- ユーザーがタスクを削除できるようにするため

---

## 変更内容

### 主な変更点

- `App.tsx`: `handleToggleTodo`関数と`handleDeleteTodo`関数を追加
- `TodoItem.tsx`: 2つの関数で取り消し線・削除を実現
- `TodoList.tsx`:  `TodoItem.tsx`に関数を渡す処理を追加

---

## テスト

### 動作確認手順

1. `npm run dev`を実行し、アプリケーションを起動
2. 「タスクを入力」フィールドにタスクをいくつか追加
3. 追加ボタンを押下するかEnterボタンを押下
4. 追加されたタスクのチェックボックスを押下し、取り消し線が引かれることを確認
5. ゴミ箱アイコンを押下し、タスクが削除されることを確認
